### PR TITLE
Add Hamming distance matrix visualization

### DIFF
--- a/hamming_layout.py
+++ b/hamming_layout.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Матрица попарных расстояний Хэмминга для кодов выбранной цифры.
+
+Берёт все коды заданной цифры из ``mnist_memory.npz``, вычисляет
+матрицу попарных расстояний Хэмминга и визуализирует её как градиент
+значений 0..1 в матрице точек (#000..#fff).
+
+Все параметры задаются константами ниже, без поддержки CLI.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from map import draw_points_matrix
+
+# Константы конфигурации
+MEMORY_FILE = "mnist_memory.npz"
+DIGIT = 3
+LIMIT = 256  # установите None, чтобы брать все коды
+OUT_PATH = "hamming_matrix.png"
+
+
+def pairwise_hamming(codes: np.ndarray) -> np.ndarray:
+    """Возвращает нормированную матрицу попарных расстояний Хэмминга."""
+    bits = np.unpackbits(codes.view(np.uint8).reshape(len(codes), -1), axis=1)
+    pop = bits.sum(axis=1, keepdims=True)
+    inter = bits @ bits.T
+    dist = pop + pop.T - 2 * inter
+    return dist / bits.shape[1]
+
+def main():
+    data = np.load(MEMORY_FILE)
+    labels = data["train_labels"]
+    mask = labels == DIGIT
+    codes = data["train_codes"][mask]
+    if LIMIT is not None:
+        codes = codes[: LIMIT]
+    if len(codes) == 0:
+        raise ValueError(f"В памяти нет кодов для цифры {DIGIT}")
+
+    mat = pairwise_hamming(codes)
+
+    n = mat.shape[0]
+    fig, ax = plt.subplots(figsize=(max(4, n / 5), max(4, n / 5)))
+    draw_points_matrix(ax, mat, square_marker=True)
+    fig.tight_layout()
+    fig.savefig(OUT_PATH, dpi=150)
+    print(f"Сохранено в {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Compute pairwise Hamming distances for all codes of a digit
- Render the distance matrix as a grayscale point grid
- Simplify script configuration by replacing CLI with module constants

## Testing
- `python hamming_layout.py`
- `python test_da.py`
- `python test_cnn.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb96a0bd0832ea2380da53f35734d