### PR TITLE
Fix Hamming distance overflow and allow point size configuration

### DIFF
--- a/hamming_layout.py
+++ b/hamming_layout.py
@@ -22,15 +22,18 @@ MEMORY_FILE = "mnist_memory.npz"
 DIGIT = 3
 LIMIT = 256  # установите None, чтобы брать все коды
 OUT_PATH = "hamming_matrix.png"
+POINT_SIZE = 100  # размер маркера точки при визуализации
 
 
 def pairwise_hamming(codes: np.ndarray) -> np.ndarray:
     """Возвращает нормированную матрицу попарных расстояний Хэмминга."""
-    bits = np.unpackbits(codes.view(np.uint8).reshape(len(codes), -1), axis=1)
+    bits = np.unpackbits(
+        codes.view(np.uint8).reshape(len(codes), -1), axis=1
+    ).astype(np.int32)
     pop = bits.sum(axis=1, keepdims=True)
-    inter = bits @ bits.T
+    inter = bits @ bits.T  # пересечение
     dist = pop + pop.T - 2 * inter
-    return dist / bits.shape[1]
+    return dist.astype(np.float32) / bits.shape[1]
 
 
 def main():
@@ -47,7 +50,7 @@ def main():
 
     n = mat.shape[0]
     fig, ax = plt.subplots(figsize=(max(4, n / 5), max(4, n / 5)))
-    draw_points_matrix(ax, mat, square_marker=True)
+    draw_points_matrix(ax, mat, square_marker=True, point_size=POINT_SIZE)
     fig.tight_layout()
 
     fig.savefig(OUT_PATH, dpi=150)

--- a/map.py
+++ b/map.py
@@ -29,7 +29,7 @@ except Exception as e:
     transforms = None
 
 # --------- утилиты рисования матрицы точек (строго #000..#fff) ---------
-def draw_points_matrix(ax, mat, title=None, square_marker=True):
+def draw_points_matrix(ax, mat, title=None, square_marker=True, point_size=100):
     """
     Рисует матрицу значений mat как решётку точек со шкалой 0..1 => #000..#fff.
     """
@@ -44,7 +44,14 @@ def draw_points_matrix(ax, mat, title=None, square_marker=True):
     colors = ['#%02x%02x%02x' % (v, v, v) for v in rgb[:, 0]]
 
     marker = 's' if square_marker else 'o'
-    ax.scatter(xs.flatten()+0.5, (h - ys.flatten()) - 0.5, c=colors, s=100, marker=marker, edgecolors='none')
+    ax.scatter(
+        xs.flatten() + 0.5,
+        (h - ys.flatten()) - 0.5,
+        c=colors,
+        s=point_size,
+        marker=marker,
+        edgecolors='none',
+    )
     ax.set_xlim(0, w); ax.set_ylim(0, h)
     ax.set_xticks([]); ax.set_yticks([])
     if title: ax.set_title(title, fontsize=10, pad=4)


### PR DESCRIPTION
## Summary
- Prevent uint8 overflow in pairwise Hamming distance computation
- Allow constant marker size via configurable point_size parameter

## Testing
- `python -m pytest -q`
- `python hamming_layout.py`


------
https://chatgpt.com/codex/tasks/task_e_68adda46cd70832e974434873fd2ed9a