### PR TITLE
Add titles and progress bars to layout scripts

### DIFF
--- a/cosine_layout.py
+++ b/cosine_layout.py
@@ -12,6 +12,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from numpy.linalg import eigh
+from tqdm import tqdm
 
 # Константы конфигурации
 MEMORY_FILE = "mnist_memory.npz"
@@ -65,18 +66,25 @@ def main():
     codes = np.concatenate(sel_codes, axis=0)
     labels = np.concatenate(sel_labels, axis=0)
 
-    mat = pairwise_cosine(codes)
+    with tqdm(total=3, desc="Создание раскладки") as pbar:
+        mat = pairwise_cosine(codes)
+        pbar.update(1)
 
-    coords = classical_mds(mat)
-    fig, ax = plt.subplots(figsize=(6, 6))
-    for digit, color in DIGIT_COLORS.items():
-        mask = labels == digit
-        ax.scatter(coords[mask, 0], coords[mask, 1], c=color, s=POINT_SIZE, label=str(digit))
-    ax.set_xticks([]); ax.set_yticks([])
-    ax.set_aspect('equal', 'datalim')
-    ax.legend(title="digit")
-    fig.tight_layout()
-    fig.savefig(OUT_LAYOUT_PATH, dpi=150)
+        coords = classical_mds(mat)
+        pbar.update(1)
+
+        fig, ax = plt.subplots(figsize=(6, 6))
+        for digit, color in DIGIT_COLORS.items():
+            mask = labels == digit
+            ax.scatter(coords[mask, 0], coords[mask, 1], c=color, s=POINT_SIZE, label=str(digit))
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_aspect('equal', 'datalim')
+        ax.legend(title="digit")
+        ax.set_title("Раскладка по косинусному расстоянию")
+        fig.tight_layout()
+        fig.savefig(OUT_LAYOUT_PATH, dpi=150)
+        pbar.update(1)
     print(f"Сохранено в {OUT_LAYOUT_PATH}")
 
 

--- a/hamming_layout.py
+++ b/hamming_layout.py
@@ -13,6 +13,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from numpy.linalg import eigh
+from tqdm import tqdm
 
 
 # Константы конфигурации
@@ -67,19 +68,26 @@ def main():
     codes = np.concatenate(sel_codes, axis=0)
     labels = np.concatenate(sel_labels, axis=0)
 
-    mat = pairwise_hamming(codes)
+    with tqdm(total=3, desc="Создание раскладки") as pbar:
+        mat = pairwise_hamming(codes)
+        pbar.update(1)
 
-    # ---- 2D-раскладка по расстояниям ----
-    coords = classical_mds(mat)
-    fig, ax = plt.subplots(figsize=(6, 6))
-    for digit, color in DIGIT_COLORS.items():
-        mask = labels == digit
-        ax.scatter(coords[mask, 0], coords[mask, 1], c=color, s=POINT_SIZE, label=str(digit))
-    ax.set_xticks([]); ax.set_yticks([])
-    ax.set_aspect('equal', 'datalim')
-    ax.legend(title="digit")
-    fig.tight_layout()
-    fig.savefig(OUT_LAYOUT_PATH, dpi=150)
+        # ---- 2D-раскладка по расстояниям ----
+        coords = classical_mds(mat)
+        pbar.update(1)
+
+        fig, ax = plt.subplots(figsize=(6, 6))
+        for digit, color in DIGIT_COLORS.items():
+            mask = labels == digit
+            ax.scatter(coords[mask, 0], coords[mask, 1], c=color, s=POINT_SIZE, label=str(digit))
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_aspect('equal', 'datalim')
+        ax.legend(title="digit")
+        ax.set_title("Раскладка по расстоянию Хэмминга")
+        fig.tight_layout()
+        fig.savefig(OUT_LAYOUT_PATH, dpi=150)
+        pbar.update(1)
     print(f"Сохранено в {OUT_LAYOUT_PATH}")
 
 


### PR DESCRIPTION
## Summary
- Add progress indicator with `tqdm` to cosine and hamming layout scripts.
- Annotate output figures with descriptive titles.

## Testing
- `pytest -q`
- `python -m py_compile cosine_layout.py hamming_layout.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae773bb394832ebba3464a5b8cac37