### PR TITLE
Add CNN feature cosine layout visualization

### DIFF
--- a/cnn_layout.py
+++ b/cnn_layout.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Визуализация попарных косинусных расстояний для признаковых векторов CNN.
+
+Берёт признаки указаных цифр из обученного ``mnist_cnn.pt``, вычисляет матрицу
+косинусных расстояний и строит 2D-раскладку методом классического MDS.
+Точки раскрашиваются в соответствии с заданными цветами для каждой цифры.
+Все параметры задаются константами ниже, без поддержки CLI.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from numpy.linalg import eigh
+from tqdm import tqdm
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader, Subset
+
+# Константы конфигурации
+WEIGHTS_PATH = "mnist_cnn.pt"
+DIGIT_COLORS = {0: "red", 1: "blue"}
+LIMIT = None  # установите None, чтобы брать все коды для каждой цифры
+OUT_LAYOUT_PATH = "cnn_layout"
+POINT_SIZE = 1  # размер маркера точки при визуализации
+
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+class Net(nn.Module):
+    """CNN как в main_cnn.py, возвращает логиты и признаки."""
+
+    def __init__(self):
+        super().__init__()
+        self.c1 = nn.Conv2d(1, 32, 3)
+        self.c2 = nn.Conv2d(32, 64, 3)
+        self.p = nn.MaxPool2d(2)
+        self.d = nn.Dropout(0.25)
+        self.f1 = nn.Linear(64 * 12 * 12, 128)
+        self.f2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = F.relu(self.c1(x))
+        x = F.relu(self.c2(x))
+        x = self.p(x)
+        x = self.d(x)
+        x = x.view(x.size(0), -1)
+        feats = F.relu(self.f1(x))
+        logits = self.f2(feats)
+        return logits, feats
+
+
+def pairwise_cosine(vecs: np.ndarray) -> np.ndarray:
+    """Возвращает матрицу попарных косинусных расстояний (1 - cos)."""
+    norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    sim = vecs @ vecs.T / (norms * norms.T)
+    return 1.0 - sim
+
+
+def classical_mds(dist: np.ndarray, n_components: int = 2) -> np.ndarray:
+    """Классическое MDS (метод Торгерсона) для раскладки по расстояниям."""
+    n = dist.shape[0]
+    H = np.eye(n) - np.ones((n, n)) / n
+    B = -0.5 * H @ (dist ** 2) @ H
+    evals, evecs = eigh(B)
+    idx = np.argsort(evals)[::-1]
+    evals, evecs = evals[idx], evecs[:, idx]
+    w = np.maximum(evals[:n_components], 0)
+    return evecs[:, :n_components] * np.sqrt(w)
+
+
+def main():
+    tfm = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,)),
+    ])
+    ds = datasets.MNIST(root="./data", train=True, transform=tfm, download=True)
+
+    net = Net().to(device)
+    net.load_state_dict(torch.load(WEIGHTS_PATH, map_location=device))
+    net.eval()
+
+    sel_codes = []
+    sel_labels = []
+    for digit in DIGIT_COLORS:
+        mask = (ds.targets == digit).nonzero(as_tuple=True)[0]
+        if LIMIT is not None:
+            mask = mask[:LIMIT]
+        if len(mask) == 0:
+            raise ValueError(f"В памяти нет примеров для цифры {digit}")
+        loader = DataLoader(Subset(ds, mask.tolist()), batch_size=256, shuffle=False)
+        feats_list = []
+        for x, _ in loader:
+            x = x.to(device)
+            _, feats = net(x)
+            feats_list.append(feats.detach().cpu().numpy())
+        feats_arr = np.concatenate(feats_list, axis=0)
+        sel_codes.append(feats_arr)
+        sel_labels.append(np.full(len(feats_arr), digit, dtype=np.int64))
+
+    codes = np.concatenate(sel_codes, axis=0)
+    labels = np.concatenate(sel_labels, axis=0)
+
+    mat = pairwise_cosine(codes)
+    coords = classical_mds(mat)
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    for digit, color in DIGIT_COLORS.items():
+        mask = labels == digit
+        ax.scatter(coords[mask, 0], coords[mask, 1], c=color, s=POINT_SIZE, label=str(digit))
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_aspect('equal', 'datalim')
+    ax.legend(title="digit")
+    ax.set_title("CNN features cosine layout")
+    fig.tight_layout()
+    file_name = "-".join([OUT_LAYOUT_PATH, *map(str, DIGIT_COLORS)]) + ".png"
+    fig.savefig(file_name, dpi=150)
+    print(f"Сохранено в {file_name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `cnn_layout.py` to visualize pairwise cosine distances of CNN feature vectors via classical MDS

## Testing
- `python -m py_compile cnn_layout.py`
- `python - <<'PY'
import cnn_layout
cnn_layout.LIMIT = 2
cnn_layout.main()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ae830016a0832e82df80d08dafc83c