### PR TITLE
feat: add densmap output to layout

### DIFF
--- a/da_layout.py
+++ b/da_layout.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from torchvision import datasets, transforms
 import matplotlib.pyplot as plt
-import umap
+from umap import UMAP
 
 # Параметры конфигурации из мета-файла
 META_JSON = "mnist_memory.meta.json"
@@ -33,6 +33,12 @@ DIGIT_COLORS = {0: "red", 1: "blue", 2: "green", 3: "yellow", 4: "orange", 5: "p
 LIMIT = None  # установите None, чтобы брать все изображения каждой цифры
 OUT_LAYOUT_PATH = "da_layout.png"
 POINT_SIZE = 1  # размер маркера точки при визуализации
+
+# Параметры UMAP
+UMAP_METRIC = "cosine"
+N_NEIGHBORS = 15
+MIN_DIST = 0.1
+OUT_DATA_PATH = "da_layout_coords.npz"
 
 
 rng = np.random.default_rng(SEED)
@@ -109,8 +115,17 @@ def main() -> None:
     digits = list(DIGIT_COLORS.keys())
     codes, labels = extract_codes(digits)
     bits = codes_to_bits(codes)
-    umap_model = umap.UMAP(n_components=2, metric="cosine", random_state=SEED)
-    coords = umap_model.fit_transform(bits)
+    umap_model = UMAP(
+        densmap=True,
+        output_dens=True,
+        random_state=SEED,
+        metric=UMAP_METRIC,
+        n_neighbors=N_NEIGHBORS,
+        min_dist=MIN_DIST,
+    )
+    coords, dens_orig, dens_emb = umap_model.fit_transform(bits)
+    dens = (dens_orig, dens_emb)
+    np.savez_compressed(OUT_DATA_PATH, coords=coords, dens_orig=dens_orig, dens_emb=dens_emb)
 
     fig, ax = plt.subplots(figsize=(6, 6))
     for digit, color in DIGIT_COLORS.items():
@@ -125,6 +140,7 @@ def main() -> None:
     fig.tight_layout()
     fig.savefig(OUT_LAYOUT_PATH, dpi=150)
     print(f"Сохранено в {OUT_LAYOUT_PATH}")
+    print(f"Координаты и плотности сохранены в {OUT_DATA_PATH}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use UMAP class directly and configure densMAP with metric, neighbors and min distance constants
- save both coordinates and density radii for further analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedee6e294832e94e8f3c7560a1ac6