### PR TITLE
Apply SVD reduction before UMAP in DA layout

### DIFF
--- a/da_layout.py
+++ b/da_layout.py
@@ -15,6 +15,7 @@ import torch
 from torchvision import datasets, transforms
 import matplotlib.pyplot as plt
 import umap
+from sklearn.decomposition import TruncatedSVD
 
 # Параметры конфигурации из мета-файла
 META_JSON = "mnist_memory.meta.json"
@@ -109,6 +110,8 @@ def main() -> None:
     digits = list(DIGIT_COLORS.keys())
     codes, labels = extract_codes(digits)
     bits = codes_to_bits(codes)
+    svd = TruncatedSVD(n_components=256, random_state=SEED)
+    bits = svd.fit_transform(bits)
     umap_model = umap.UMAP(n_components=2, metric="cosine", random_state=SEED)
     coords = umap_model.fit_transform(bits)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 numpy
 flask
 umap-learn
+scikit-learn


### PR DESCRIPTION
## Summary
- Reduce bit vectors with `TruncatedSVD` before UMAP projection in `da_layout.py`
- Add scikit-learn to requirements for SVD support

## Testing
- `pytest -q`
- `python -m py_compile da_layout.py`


------
https://chatgpt.com/codex/tasks/task_e_68aee5e1e204832e8fd5293a3691563d